### PR TITLE
improve CI (automation of tests and doc)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+ignore =
+    # E203: whitespace before ':' - doesn't work well with black
+    # E402: module level import not at top of file
+    # E501: line too long - let black worry about that
+    # E731: do not assign a lambda expression, use a def
+    # W503: line break before binary operator
+    E203,E402,E501,E731,W503
+exclude=
+    .eggs
+    docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+ci:
+  autoupdate_schedule: weekly
+
+# https://pre-commit.com/
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: check-yaml
+      - id: check-toml
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+      - id: black-jupyter
+  - repo: https://github.com/keewis/blackdoc
+    rev: v0.3.8
+    hooks:
+      - id: blackdoc
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout
+        args: [--extra-keys=metadata.kernelspec metadata.language_info.version]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.4
+    hooks:
+      - id: prettier

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
+    pre_install:
+      - git update-index --assume-unchanged docs/conf.py ci/requirements/docs.yaml
+
+conda:
+  environment: ci/requirements/docs.yaml
+
+sphinx:
+  fail_on_warning: true
+  configuration: docs/conf.py
+
+formats: []

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -1,0 +1,18 @@
+name: xsarslc-docs
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - sphinx>=4
+  - sphinx-book-theme
+  - ipython
+  - myst-parser
+  - jinja2<=3.03
+  - pandoc
+  - numpydoc
+  - sphinx-rtd-theme
+  - nbsphinx
+  - jupyter-sphinx
+  - sphinxcontrib-programoutput
+  - aiohttp
+  - holoviews

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -1,0 +1,36 @@
+name: xsarslc-tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  # development
+  - ipython
+  - pre-commit
+  - jupyterlab
+  - jupyterlab_code_formatter
+  - isort
+  - black
+  - dask-labextension
+  # testing
+  - pytest
+  - pytest-reportlog
+  - hypothesis
+  - coverage
+  # I/O
+  - rioxarray
+  - h5netcdf
+  - zarr
+  - scipy
+  # data
+  - xarray
+  - xarray-datatree
+  - dask
+  - numpy
+  - pandas
+  - shapely
+  - cartopy
+  # processing
+  - more-itertools
+  - tqdm
+  - lxml
+  - importlib_resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=64.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-#packages = ["xsar_slc.srcipts.L1B_xspectra_IW_SLC_IFR.py"]
+packages = ["xsarslc"]
 
 [tool.setuptools_scm]
 fallback_version = "999"
@@ -32,3 +32,4 @@ profile = "black"
 skip_gitignore = true
 float_to_top = true
 default_section = "THIRDPARTY"
+known_first_party = "xsarslc"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[flake8]
-ignore =
-  E203 # whitespace before ':' - doesn't work well with black
-  E402 # module level import not at top of file
-  E501 # line too long - let black worry about that
-  E731 # do not assign a lambda expression, use a def
-  W503 # line break before binary operator
-exclude =
-  .eggs

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup,find_packages
-import glob
-if __name__ == "__main__":
-    # setup(
-    #     name='xsarslc',
-    #     package_dir={'': 'xsarslc'},
-    #     packages=find_packages('xsarslc'),
-    #     scripts=glob.glob('scripts/*.py'),)
-    setup()


### PR DESCRIPTION
Sphinx docs will be publish through readthedocs instead of github pages.
based on good pratices (mostly copy pasted from https://github.com/umr-lops/xarray-safe-rcm )
add

- [x]  .flake8 
- [x]  .pre-commit-config.yaml 
- [x]  .readthedocs.yml 
- [x] ci/requirements/docs.yaml 
- [x] ci/requirements/environment.yaml