### PR TITLE
Update docs.yaml

### DIFF
--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -16,4 +16,5 @@ dependencies:
   - sphinxcontrib-programoutput
   - aiohttp
   - holoviews
-  - xsarslc
+  - pip:
+    - -e ../..

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -16,3 +16,4 @@ dependencies:
   - sphinxcontrib-programoutput
   - aiohttp
   - holoviews
+  - xsarslc


### PR DESCRIPTION
missing dependency `xsarslc` for documentation sphinx. -> fixed with `-e ../..` in docs.yaml
adress #51 

- [ ] make the input files used in the doc downloadable through https 