### PR TITLE
fix typo pol -> polarization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires-python = ">= 3.9"
 description = "Python library to compute cross spectra from SAR image"
 readme.file = "README.md"
 readme.content-type = "text/markdown"
-license.text = "GPL-3.0"
-license.file = "LICENSE.md"
+#license.text = "GPL-3.0"
+license = {text = "GPL-3.0"}
 keywords = ["SAR", "wave", "reseach", "cross-spectra"]
 authors = [
   {name = "Frederic Nouguier"}

--- a/scripts/L1B_xspectra_IW_SLC_IFR.py
+++ b/scripts/L1B_xspectra_IW_SLC_IFR.py
@@ -72,12 +72,12 @@ def generate_IW_L1Bxspec_product(slc_iw_path,output_filename, polarization=None,
     IR_dir = '/home/datawork-cersat-public/project/sarwave/data/products/developments/aux_files/sar/impulse_response/'
     IR_path = get_IR_file(unit, subswath, polarization.upper(), auxdir=IR_dir)
     if IR_path:
-        one_subswath_xspectrum_dt = proc.compute_subswath_xspectra(dt,pol=polarization.upper(),
+        one_subswath_xspectrum_dt = proc.compute_subswath_xspectra(dt,polarization=polarization.upper(),
                                                                dev=dev,compute_intra_xspec=True,
                                                                compute_inter_xspec=True,tile_width=tile_width,
                                                                tile_overlap=tile_overlap,IR_path=IR_path)
     else:
-        one_subswath_xspectrum_dt = proc.compute_subswath_xspectra(dt,pol=polarization.upper(),
+        one_subswath_xspectrum_dt = proc.compute_subswath_xspectra(dt,polarization=polarization.upper(),
                                                                dev=dev,compute_intra_xspec=True,
                                                                compute_inter_xspec=True,tile_width=tile_width,
                                                                tile_overlap=tile_overlap)


### PR DESCRIPTION
it is supposed to fix #49 .
(on top of this typo there was a wrong sigma0_lut used for cross pol in `xsar` fixed with https://github.com/umr-lops/xsar/pull/144